### PR TITLE
Update mangos-installer

### DIFF
--- a/mangos-installer
+++ b/mangos-installer
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-PKG_APT="git patch cmake make gcc g++ libtbb-dev libmysqld-dev libboost-dev zlib1g-dev libssl-dev automake"
+PKG_APT="git patch cmake make gcc g++ libtbb-dev libmysqld-dev libboost-all-dev zlib1g-dev libssl-dev automake"
 PKG_RPM="git patch cmake make gcc gcc-c++ tbb-devel mysql-devel zlib-devel openssl-devel automake"
 
 LOG_FILE="$PWD/mangos-installer.log"

--- a/mangos-installer
+++ b/mangos-installer
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-PKG_APT="git patch cmake make gcc g++ libtbb-dev libmysqld-dev zlib1g-dev libssl-dev automake"
+PKG_APT="git patch cmake make gcc g++ libtbb-dev libmysqld-dev libboost-dev zlib1g-dev libssl-dev automake"
 PKG_RPM="git patch cmake make gcc gcc-c++ tbb-devel mysql-devel zlib-devel openssl-devel automake"
 
 LOG_FILE="$PWD/mangos-installer.log"


### PR DESCRIPTION
"Cmake" could not be executed, because of missing "Boost" dev-lib (Debian Jessie, 8.6, plain)